### PR TITLE
sepolicy Allow app_zygote to read /dev/ion

### DIFF
--- a/sepolicy/app_zygote.te
+++ b/sepolicy/app_zygote.te
@@ -1,0 +1,1 @@
+allow app_zygote ion_device:chr_file r_file_perms;


### PR DESCRIPTION
Regular Zygote does already have this permission granted as part of
system/sepolicy. Legacy QCOM devices combined with AOSP Webview
processes appear to fail to load in enforcing mode without this change.

TEST: Without this patch, opening Chrome on shamu results in:

avc: denied { getattr } for comm="d.chrome_zygote" path="/data/data/com.android.chrome" dev="mmcblk0p42" ino=1832060 scontext=u:r:app_zygote:s0:c166,c256,c512,c768 tcontext=u:object_r:app_data_file:s0:c166,c256,c512,c768 tclass=dir permissive=1 app=com.android.chrome
avc: denied { read } for comm="d.chrome_zygote" name="ion" dev="tmpfs" ino=9288 scontext=u:r:app_zygote:s0:c166,c256,c512,c768 tcontext=u:object_r:ion_device:s0 tclass=chr_file permissive=1 app=com.android.chrome
avc: denied { open } for comm="d.chrome_zygote" path="/dev/ion" dev="tmpfs" ino=9288 scontext=u:r:app_zygote:s0:c166,c256,c512,c768 tcontext=u:object_r:ion_device:s0 tclass=chr_file permissive=1 app=com.android.chrome

Change-Id: If1f90d7ca99b3bc503b8506e1db27b01e9cc0fe1