### PR TITLE
shamu: Disable audio rotation tracking

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -14,7 +14,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.audio.fluence.voicecomm=false \
     persist.audio.fluence.voicerec=false \
     ro.audio.flinger_standbytime_ms=300 \
-    ro.audio.monitorRotation=true \
     ro.config.media_vol_steps=25 \
     ro.config.vc_call_vol_steps=7 \
     ro.qc.sdk.audio.fluencetype=fluence


### PR DESCRIPTION
* This results in annoying audio ducks, and some
  issues with in-call audio.

Change-Id: I1c82dc36b9cfb53354e59e5740ee808553204380