### PR TITLE
shamu: Don't go breaking my HAL

### DIFF
--- a/rootdir/etc/init.shamu.rc
+++ b/rootdir/etc/init.shamu.rc
@@ -382,7 +382,10 @@ on property:sys.boot_completed=1
 
     swapon_all /vendor/etc/fstab.shamu
 
-    restart cameraserver
+    stop cameraserver
+    start qcamerasvr
+    start cameraserver
+    start mpdecision
 
 on property:ro.data.large_tcp_window_size=true
     # Adjust socket buffer to enlarge TCP receive window for high bandwidth (e.g. DO-RevB)
@@ -416,7 +419,8 @@ service qseecomd /system/bin/qseecomd
 service mpdecision /system/vendor/bin/mpdecision --avg_comp
     class main
     user root
-    group root system readproc diag 
+    group root system readproc diag
+    disabled
     writepid /dev/cpuset/system-background/tasks
 
 service thermal-engine /system/vendor/bin/thermal-engine
@@ -432,9 +436,10 @@ service time_daemon /system/bin/time_daemon
     writepid /dev/cpuset/system-background/tasks
 
 service qcamerasvr /system/bin/mm-qcamera-daemon
-    class main
+    class late_start
     user camera
     group camera system inet input graphics
+    disabled
     writepid /dev/cpuset/camera-daemon/tasks
 
 service bdAddrLoader /system/vendor/bin/bdAddrLoader_shamu -p ro.boot.btmacaddr -s -x
@@ -478,9 +483,3 @@ service devstart_sh /vendor/bin/init.qcom.devstart.sh
     group root system
     disabled
     oneshot
-
-on property:init.svc.media=restarting
-    restart qcamerasvr
-
-on property:init.svc.servicemanager=restarting
-    restart qcamerasvr


### PR DESCRIPTION
Ooh-hoo, nobody knows it
When it was down
I was your clown
Ooh-hoo, nobody knows it, nobody knows
Right from the start

* On some devices camera HAL doesn't come up reliable.
  Camereraserver needs qcamerasver to connect to.
  As we have no direct control over when cameraserver starts
  we're trying to bring up the services in the right order at
  the 'boot complete' step.

* Disable mpdecision and starting it at 'boot complete' to reduce
  interference with the timing of service starts

* Remove all the fiddling with services we did before in an attempt
  to mitigate the breakage

Change-Id: Ie45d8310dc025dd34eaab063f0f64fde829ba144