### PR TITLE
shamu: Don't go breaking my HAL part 2

### DIFF
--- a/rootdir/etc/init.shamu.rc
+++ b/rootdir/etc/init.shamu.rc
@@ -384,8 +384,9 @@ on property:sys.boot_completed=1
 
     stop cameraserver
     start qcamerasvr
+
+on property:init.svc.qcamerasvr=running
     start cameraserver
-    start mpdecision
 
 on property:ro.data.large_tcp_window_size=true
     # Adjust socket buffer to enlarge TCP receive window for high bandwidth (e.g. DO-RevB)
@@ -420,7 +421,6 @@ service mpdecision /system/vendor/bin/mpdecision --avg_comp
     class main
     user root
     group root system readproc diag
-    disabled
     writepid /dev/cpuset/system-background/tasks
 
 service thermal-engine /system/vendor/bin/thermal-engine


### PR DESCRIPTION
* Starting services in a specific order doesn't make much sense
  as 'start' isn't synchronus
  Reference:
  https://android.googlesource.com/platform/system/core/+/master/init/README.md

* Make starting cameraserver dependent on qcamerasver running

Change-Id: I86aafc387e731550d518d7f3e8241299b8e5a1a1