### PR TITLE
shamu: Add dataservices to PRODUCT_SOONG_NAMESPACES

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -78,6 +78,10 @@ PRODUCT_PACKAGES += \
 # Characteristics
 PRODUCT_CHARACTERISTICS := nosdcard
 
+# Data (CAF)
+PRODUCT_SOONG_NAMESPACES += \
+    vendor/qcom/opensource/dataservices
+
 # Dex-pre-opt exclusions
 $(call add-product-dex-preopt-module-config,MotoSignatureApp,disable)
 


### PR DESCRIPTION
* Topic `dataservices_namespace` isolated
  `vendor/qcom/opensource/dataservices` into its own soong namespace,
  and added it to PRODUCT_SOONG_NAMESPACE by default if
  BOARD_USES_QCOM_HARDWARE is set.
* Our devices needs QCOM OSS dataservices (librmnetctl) but does not
  use CAF HALs by default, so we have to add this to our soong
  namespaces ourselves.

Change-Id: Ic2487d7b8e6e88bf13590dc51a2df04f5c31a05b