### PR TITLE
shamu: Enable Wi-Fi Display

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -294,4 +294,8 @@
 
     <!-- Disable rounded corners on windows to improve graphics performance -->
     <bool name="config_supportsRoundedCornersOnWindows">false</bool>
+
+    <!-- AOSP WFD -->
+    <bool name="config_enableWifiDisplay">true</bool>
+
 </resources>


### PR DESCRIPTION
* AOSP Wi-Fi display is back in lineage-18.1.

Change-Id: I7958fc6869a22d66ad2955f80c4ea1867bdc23fd